### PR TITLE
Copy executables to parent build directory

### DIFF
--- a/wscript
+++ b/wscript
@@ -49,6 +49,25 @@ def build(bld):
     bld.recurse('polynomials')
     bld.recurse('sdr')
 
+    if not (bld.cmd == 'docu'):
+        bld.add_group()
+
+        bld(
+            rule = 'cp ${SRC} ${TGT[0].abspath()}',
+            source = bld.path.find_or_declare('sdr/seeder'),
+            target = 'musubi'
+        )
+        bld(
+            rule = 'cp ${SRC} ${TGT[0].abspath()}',
+            source = bld.path.find_or_declare('sdr/sdr_harvesting'),
+            target = 'mus_harvesting'
+        )
+        bld(
+            rule = 'cp ${SRC} ${TGT[0].abspath()}',
+            source = bld.path.find_or_declare('aotus/lua'),
+            target = 'lua'
+        )
+
 #clean build directory and coco completely to create the build from scratch
 def cleanall(ctx):
     from waflib import Options


### PR DESCRIPTION
This puts the executables again in the expected place, as in the nested repository layout.