### PR TITLE
Use the apes-suite/build-action to compile seeder

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,4 +1,4 @@
-name: CheckCompilation
+name: Compilation and Unit Tests
 
 on:
   pull_request:
@@ -16,6 +16,6 @@ jobs:
           submodules: recursive
 
       - name: Build Seeder
-        uses: apes-suite/build-action@v1
+        uses: apes-suite/build-action@v1.1.1
         with:
           waf-args: "configure build debug"

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -15,19 +15,7 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install gfortran
-        run: |
-          sudo apt install -y gfortran
-
-      - name: Install Open MPI
-        run: |
-          sudo apt install -y openmpi-bin openmpi-common libopenmpi-dev
-
-      - name: Install Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-
       - name: Build Seeder
-        run: |
-          FC=mpif90 bin/waf --mpicmd 'mpiexec --oversubscribe' distclean configure build debug
+        uses: apes-suite/build-action@v1
+        with:
+          waf-args: "configure build debug"

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,4 +1,4 @@
-name: Compilation and Unit Tests
+name: Compilation and UTests
 
 on:
   pull_request:
@@ -8,6 +8,9 @@ on:
 
 jobs:
   compilation:
+    permissions:
+      checks: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -19,3 +22,10 @@ jobs:
         uses: apes-suite/build-action@v1.1.1
         with:
           waf-args: "configure build debug"
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2.19.0
+        with:
+          files: |
+            build/**/waf-utest.xml
+          check_name: "Waf Unit Tests"

--- a/.github/workflows/ford.yml
+++ b/.github/workflows/ford.yml
@@ -1,6 +1,7 @@
 name: Fordoc
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'main'
@@ -21,34 +22,14 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install gfortran
-        run: |
-          sudo apt install -y gfortran
-
-      - name: Install Open MPI
-        run: |
-          sudo apt install -y openmpi-bin openmpi-common libopenmpi-dev
-
-      - name: Install Python
-        uses: actions/setup-python@v5
+      - name: Build Seeder Documentation
+        uses: apes-suite/build-action@v1.1.1
         with:
-          python-version: '3.13'
-
-      - name: Install Graphviz
-        uses: ts-graphviz/setup-graphviz@v2
-
-      - name: Install FORD
-        run: |
-          python -m pip install --upgrade pip
-          pip install ford
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-
-      - name: Build FORD Documentation
-        run: |
-          FC=mpif90 bin/waf --fordonline distclean configure docu
+          waf-args: "--fordonline configure docu"
+          obtain: "build/ford/sdr/docu"
 
       - name: Deploy Documentation
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
-          folder: build/ford/sdr/docu
+          folder: docu


### PR DESCRIPTION
Instead of installing additional dependencies, make use of the docker action
that runs the waf command accordingly.
